### PR TITLE
Dark mode review

### DIFF
--- a/google-maps-sample/src/main/res/raw/night_style.json
+++ b/google-maps-sample/src/main/res/raw/night_style.json
@@ -1,0 +1,186 @@
+[
+  {
+    "elementType": "geometry",
+    "stylers": [
+      {
+        "color": "#212121"
+      }
+    ]
+  },
+  {
+    "elementType": "labels.icon",
+    "stylers": [
+      {
+        "visibility": "off"
+      }
+    ]
+  },
+  {
+    "elementType": "labels.text.fill",
+    "stylers": [
+      {
+        "color": "#757575"
+      }
+    ]
+  },
+  {
+    "elementType": "labels.text.stroke",
+    "stylers": [
+      {
+        "color": "#212121"
+      }
+    ]
+  },
+  {
+    "featureType": "administrative",
+    "elementType": "geometry",
+    "stylers": [
+      {
+        "color": "#757575"
+      }
+    ]
+  },
+  {
+    "featureType": "administrative.country",
+    "elementType": "labels.text.fill",
+    "stylers": [
+      {
+        "color": "#9e9e9e"
+      }
+    ]
+  },
+  {
+    "featureType": "administrative.land_parcel",
+    "stylers": [
+      {
+        "visibility": "off"
+      }
+    ]
+  },
+  {
+    "featureType": "administrative.locality",
+    "elementType": "labels.text.fill",
+    "stylers": [
+      {
+        "color": "#bdbdbd"
+      }
+    ]
+  },
+  {
+    "featureType": "poi",
+    "elementType": "labels.text.fill",
+    "stylers": [
+      {
+        "color": "#757575"
+      }
+    ]
+  },
+  {
+    "featureType": "poi.park",
+    "elementType": "geometry",
+    "stylers": [
+      {
+        "color": "#181818"
+      }
+    ]
+  },
+  {
+    "featureType": "poi.park",
+    "elementType": "labels.text.fill",
+    "stylers": [
+      {
+        "color": "#616161"
+      }
+    ]
+  },
+  {
+    "featureType": "poi.park",
+    "elementType": "labels.text.stroke",
+    "stylers": [
+      {
+        "color": "#1b1b1b"
+      }
+    ]
+  },
+  {
+    "featureType": "road",
+    "elementType": "geometry.fill",
+    "stylers": [
+      {
+        "color": "#2c2c2c"
+      }
+    ]
+  },
+  {
+    "featureType": "road",
+    "elementType": "labels.text.fill",
+    "stylers": [
+      {
+        "color": "#8a8a8a"
+      }
+    ]
+  },
+  {
+    "featureType": "road.arterial",
+    "elementType": "geometry",
+    "stylers": [
+      {
+        "color": "#373737"
+      }
+    ]
+  },
+  {
+    "featureType": "road.highway",
+    "elementType": "geometry",
+    "stylers": [
+      {
+        "color": "#3c3c3c"
+      }
+    ]
+  },
+  {
+    "featureType": "road.highway.controlled_access",
+    "elementType": "geometry",
+    "stylers": [
+      {
+        "color": "#4e4e4e"
+      }
+    ]
+  },
+  {
+    "featureType": "road.local",
+    "elementType": "labels.text.fill",
+    "stylers": [
+      {
+        "color": "#616161"
+      }
+    ]
+  },
+  {
+    "featureType": "transit",
+    "elementType": "labels.text.fill",
+    "stylers": [
+      {
+        "color": "#757575"
+      }
+    ]
+  },
+  {
+    "featureType": "water",
+    "elementType": "geometry",
+    "stylers": [
+      {
+        "color": "#000000"
+      }
+    ]
+  },
+  {
+    "featureType": "water",
+    "elementType": "labels.text.fill",
+    "stylers": [
+      {
+        "color": "#3d3d3d"
+      }
+    ]
+  }
+]

--- a/lib/src/main/java/com/what3words/components/maps/views/W3WGoogleMapFragment.kt
+++ b/lib/src/main/java/com/what3words/components/maps/views/W3WGoogleMapFragment.kt
@@ -18,6 +18,7 @@ import com.what3words.components.maps.models.W3WApiDataSource
 import com.what3words.components.maps.models.W3WDataSource
 import com.what3words.components.maps.models.W3WMarkerColor
 import com.what3words.components.maps.models.W3WZoomOption
+import com.what3words.components.maps.wrappers.GridColor
 import com.what3words.components.maps.wrappers.W3WGoogleMapsWrapper
 import com.what3words.javawrapper.response.APIResponse
 import com.what3words.javawrapper.response.Suggestion
@@ -121,6 +122,10 @@ class W3WGoogleMapFragment() : Fragment(), OnMapReadyCallback, W3WMap {
 
     override fun setLanguage(language: String) {
         w3wMapsWrapper.setLanguage(language)
+    }
+
+    override fun setGridColor(gridColor: GridColor) {
+        w3wMapsWrapper.setGridColor(gridColor)
     }
 
     override fun onSquareSelected(ssc: SelectedSquareConsumer<SuggestionWithCoordinates, Boolean, Boolean>) {

--- a/lib/src/main/java/com/what3words/components/maps/views/W3WMap.kt
+++ b/lib/src/main/java/com/what3words/components/maps/views/W3WMap.kt
@@ -3,6 +3,7 @@ package com.what3words.components.maps.views
 import androidx.core.util.Consumer
 import com.what3words.components.maps.models.W3WMarkerColor
 import com.what3words.components.maps.models.W3WZoomOption
+import com.what3words.components.maps.wrappers.GridColor
 import com.what3words.javawrapper.response.APIResponse
 import com.what3words.javawrapper.response.Suggestion
 import com.what3words.javawrapper.response.SuggestionWithCoordinates
@@ -19,6 +20,16 @@ interface W3WMap {
      * @param language a supported 3 word address language as an ISO 639-1 2 letter code. Defaults to en (English).
      */
     fun setLanguage(language: String)
+
+    /** Due to different map providers setting Dark/Light modes differently i.e: GoogleMaps sets dark mode using JSON styles but Mapbox has dark mode as a MapType.
+     *
+     * [GridColor.AUTO] - Will leave up to the library to decide which Grid color and selected square color to use to match some specific map types, i.e: use [GridColor.DARK] on normal map types, [GridColor.LIGHT] on Satellite and Traffic map types.
+     * [GridColor.LIGHT] - Will force grid and selected square color to be light.
+     * [GridColor.DARK] - Will force grid and selected square color to be dark.
+     *
+     * @param gridColor set grid color, per default will be [GridColor.AUTO].
+     */
+    fun setGridColor(gridColor: GridColor)
 
     /** A callback for when a square is selected either by clicking on the map or programmatically using any of [selectAtWords], [selectAtCoordinates], [selectAtSuggestion].
      *

--- a/lib/src/main/java/com/what3words/components/maps/views/W3WMapboxMapFragment.kt
+++ b/lib/src/main/java/com/what3words/components/maps/views/W3WMapboxMapFragment.kt
@@ -16,8 +16,8 @@ import com.what3words.components.maps.models.W3WApiDataSource
 import com.what3words.components.maps.models.W3WDataSource
 import com.what3words.components.maps.models.W3WMarkerColor
 import com.what3words.components.maps.models.W3WZoomOption
+import com.what3words.components.maps.wrappers.GridColor
 import com.what3words.components.maps.wrappers.W3WMapBoxWrapper
-import com.what3words.javawrapper.request.Coordinates
 import com.what3words.javawrapper.response.APIResponse
 import com.what3words.javawrapper.response.Suggestion
 import com.what3words.javawrapper.response.SuggestionWithCoordinates
@@ -403,6 +403,10 @@ class W3WMapboxMapFragment() : Fragment(), W3WMap {
 
     override fun removeMarkerAtCoordinates(listCoordinates: List<Pair<Double, Double>>) {
         w3wMapsWrapper.removeMarkerAtCoordinates(listCoordinates)
+    }
+
+    override fun setGridColor(gridColor: GridColor) {
+        w3wMapsWrapper.setGridColor(gridColor)
     }
 
     override fun removeAllMarkers() {

--- a/lib/src/main/java/com/what3words/components/maps/wrappers/W3WMapWrapper.kt
+++ b/lib/src/main/java/com/what3words/components/maps/wrappers/W3WMapWrapper.kt
@@ -8,6 +8,12 @@ import com.what3words.javawrapper.response.APIResponse
 import com.what3words.javawrapper.response.Suggestion
 import com.what3words.javawrapper.response.SuggestionWithCoordinates
 
+enum class GridColor {
+    AUTO,
+    DARK,
+    LIGHT
+}
+
 /** What3words abstract map wrapper interface, every new map provider wrapper added to the component should implement this interface. */
 interface W3WMapWrapper {
 
@@ -16,6 +22,16 @@ interface W3WMapWrapper {
      * @param language a supported 3 word address language as an ISO 639-1 2 letter code. Defaults to en (English).
      */
     fun setLanguage(language: String): W3WMapWrapper
+
+    /** Due to different map providers setting Dark/Light modes differently i.e: GoogleMaps sets dark mode using JSON styles but Mapbox has dark mode as a MapType.
+     *
+     * [GridColor.AUTO] - Will leave up to the library to decide which Grid color and selected square color to use to match some specific map types, i.e: use [GridColor.DARK] on normal map types, [GridColor.LIGHT] on Satellite and Traffic map types.
+     * [GridColor.LIGHT] - Will force grid and selected square color to be light.
+     * [GridColor.DARK] - Will force grid and selected square color to be dark.
+     *
+     * @param gridColor set grid color, per default will be [GridColor.AUTO].
+     */
+    fun setGridColor(gridColor: GridColor)
 
     /** Enable grid overlay over map with all 3mx3m squares on the visible map bounds.
      *

--- a/lib/src/main/res/values/colors.xml
+++ b/lib/src/main/res/values/colors.xml
@@ -1,10 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <color name="grid_gone">#00e5e5e5</color>
-    <color name="grid_mapbox">#29072f4a</color>
-    <color name="grid_far">#88C0C0C0</color>
-    <color name="grid_middle">#BBC0C0C0</color>
-    <color name="grid_close">#FFC0C0C0</color>
+    <color name="grid_light">#1AEBEBEB</color>
+    <color name="grid_dark">#29292929</color>
     <color name="grid_selected_normal">#0A3049</color>
     <color name="grid_selected_sat">#FFF</color>
     <color name="grid_filled">#E11F26</color>

--- a/lib/src/main/res/values/dimens.xml
+++ b/lib/src/main/res/values/dimens.xml
@@ -2,8 +2,6 @@
 <resources xmlns:tools="http://schemas.android.com/tools">
     <dimen name="grid_width_gone">0dp</dimen>
     <dimen name="grid_width_close">1dp</dimen>
-    <dimen name="grid_width_middle">1dp</dimen>
-    <dimen name="grid_width_far">1dp</dimen>
     <dimen name="grid_selected_width_close">2.5dp</dimen>
     <dimen name="grid_selected_width_middle">2dp</dimen>
     <dimen name="grid_selected_width_far">1.5dp</dimen>


### PR DESCRIPTION
After looking on how to enable dark mode on maps, noticed that I didn't account for all the other map types and styles, with setGridColor() which is GridColor.AUTO by default will give the developer a way to force the color of our grid in case our internal automatic logic doesn't work for the specific case scenario. Grid colours change according to this figma file: https://www.figma.com/file/dUoC2KtbJSLYH80Cu2uy7i/WEB-Design-System?node-id=1351%3A3266