### PR TITLE
SDK 34 update

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,16 +29,16 @@ jobs:
       - run:
           name: Run Tests
           command: ./gradlew lib:testDebugUnitTest lib:jacocoTestReport
-#      - run:
-#          name: Upload Coverage Report to SonarCloud
-#          command: ./gradlew sonarqube
+      #      - run:
+      #          name: Upload Coverage Report to SonarCloud
+      #          command: ./gradlew sonarqube
       - store_test_results:
           path: lib/build/test-results/testDebugUnitTest
   deploy-to-sonatype:
-    docker:
-      - image: cimg/android:2023.05-browsers
-    environment:
-      JVM_OPTS: -Xmx3200m
+    executor:
+      name: android/android-machine
+      resource-class: large
+      tag: 2023.05.1
     steps:
       - checkout
       - restore_cache:
@@ -57,6 +57,10 @@ jobs:
             - ~/.gradle
           key: jars-{{ checksum "build.gradle" }}-{{ checksum  "lib/build.gradle" }}
       - run:
+          name: Snapshot Release Check
+          command: |
+            echo -e "\nIS_SNAPSHOT_RELEASE=$( [[ "${CIRCLE_BRANCH}" =~ ^epic.* ]] && echo true || echo false )" >> gradle.properties
+      - run:
           name: Inject Maven signing key
           command: |
             chmod +x signing.sh
@@ -73,14 +77,14 @@ workflows:
             - maven-sign
             - mobile
       - deploy-to-sonatype:
-          name: Build, run tests, sonar and push to maven staging
+          name: Deploy to sonatype and build sample apps
           requires:
             - build-test-sonar
           context:
-            - SonarCloud
-            - maven-sign
             - mobile
+            - maven-sign
           filters:
             branches:
               only:
                 - staging
+                - /^epic.*/

--- a/build.gradle
+++ b/build.gradle
@@ -1,26 +1,6 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 buildscript {
     ext {
-        what3words_android_wrapper_version = "3.2.0"
-        what3words_android_bridge_version = "1.0.5"
-        what3words_android_design_version = "1.0.3"
-        compose_version = "1.4.3"
-        compose_activity_version = "1.7.2"
-        compose_constraint_layout_version = "1.0.1"
-        androidx_test_core = "1.5.0"
-        androidx_arch_core = "2.2.0"
-        google_truth = '1.1.3'
-        coroutines_version = '1.7.3'
-        espresso_version = "3.5.1"
-        mockk_version = '1.13.5'
-        junit_version = "4.13.2"
-        test_runner_version = "1.5.2"
-        gms_version = "18.2.0"
-        gms_utils_version = "2.4.0"
-        mapbox_version = "10.4.0"
-        androidx_core_ktx_version = "1.10.1"
-        androidx_appcompat_version = "1.6.1"
-        material_version= "1.9.0"
         coverageExclusions = ['**/BR.*',
                               '**/R.class',
                               '**/R$*.class',
@@ -29,7 +9,6 @@ buildscript {
                               '**/*Test*.*',
                               'android/**/*.*',
                               'androidx/**/*.*',]
-        agp_version = '8.1.3'
     }
     dependencies {
         classpath "com.google.android.libraries.mapsplatform.secrets-gradle-plugin:secrets-gradle-plugin:2.0.1"
@@ -40,8 +19,7 @@ buildscript {
 
 plugins {
     id 'org.jlleitschuh.gradle.ktlint' version '10.1.0' apply false
-    id "com.android.application" version "$agp_version" apply false
-    id 'com.android.library' version '8.0.1' apply false
+    id 'com.android.library' version '8.5.0' apply false
     id 'org.jetbrains.kotlin.android' version '1.8.20' apply false
     id "com.autonomousapps.dependency-analysis" version "1.20.0"
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -23,4 +23,5 @@ android.nonTransitiveRClass=true
 kotlin.code.style=official
 android.defaults.buildfeatures.buildconfig=true
 android.nonFinalResIds=false
+VERSION_NAME=1.0.5
 MAPBOX_DOWNLOADS_TOKEN = "YOUR_MAPBOX_DOWNLOADS_TOKEN"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Wed Mar 02 12:34:50 GMT 2022
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME

--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -7,17 +7,22 @@ plugins {
     id 'org.jetbrains.dokka' version '1.5.0'
 }
 
-def libVersion = findProperty('LIBRARY_VERSION') ? findProperty('LIBRARY_VERSION') : "1.0-debug"
+/**
+ * IS_SNAPSHOT_RELEASE property will be automatically added to the root gradle.properties file by the CI pipeline, depending on the GitHub branch.
+ * A snapshot release is generated for every pull request merged or commit made into an epic branch.
+ */
+def isSnapshotRelease = findProperty('IS_SNAPSHOT_RELEASE') == 'true'
+def libVersion = isSnapshotRelease ? "${findProperty('VERSION_NAME')}-SNAPSHOT" : findProperty('VERSION_NAME')
 
 apply from: 'maven-push.gradle'
 apply from: '../jacoco.gradle'
 
 android {
-    compileSdk 33
+    compileSdk 34
 
     defaultConfig {
         minSdk 24
-        targetSdk 33
+        targetSdk 34
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles "consumer-rules.pro"
@@ -72,30 +77,28 @@ android {
 }
 
 dependencies {
-    // android
-    implementation "com.google.android.material:material:$material_version"
-
+    implementation "com.google.android.material:material:1.12.0"
     // what3words
-    api "com.what3words:w3w-android-wrapper:$what3words_android_wrapper_version"
-    api "com.what3words:w3w-android-api-sdk-bridge:$what3words_android_bridge_version"
+    api "com.what3words:w3w-android-wrapper:4.0.2-SNAPSHOT"
+    api "com.what3words:w3w-android-api-sdk-bridge:1.0.8-SNAPSHOT"
 
     // Google maps
-    compileOnly "com.google.android.gms:play-services-maps:$gms_version"
-    compileOnly "com.google.maps.android:android-maps-utils:$gms_utils_version"
-    testImplementation "com.google.android.gms:play-services-maps:$gms_version"
+    compileOnly "com.google.android.gms:play-services-maps:19.0.0"
+    compileOnly "com.google.maps.android:android-maps-utils:3.4.0"
+    testImplementation "com.google.android.gms:play-services-maps:19.0.0"
 
     // Mapbox
-    compileOnly "com.mapbox.maps:android:$mapbox_version"
+    compileOnly "com.mapbox.maps:android:10.18.3"
 
     // kotlin
-    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:$coroutines_version"
-    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:$coroutines_version"
-    testImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-test:$coroutines_version"
+    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:1.8.1"
+    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:1.8.1"
+    testImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-test:1.8.1"
 
     // Testing
-    testImplementation "junit:junit:$junit_version"
-    testImplementation "androidx.test:core:$androidx_test_core"
-    testImplementation "com.google.truth:truth:$google_truth"
-    testImplementation "io.mockk:mockk:$mockk_version"
-    testImplementation "androidx.arch.core:core-testing:$androidx_arch_core"
+    testImplementation "junit:junit:4.13.2"
+    testImplementation "androidx.test:core:1.6.1"
+    testImplementation "com.google.truth:truth:1.4.2"
+    testImplementation "io.mockk:mockk:1.13.5"
+    testImplementation "androidx.arch.core:core-testing:2.2.0"
 }

--- a/lib/maven-push.gradle
+++ b/lib/maven-push.gradle
@@ -2,7 +2,13 @@ def ossrhUsername = findProperty('OSSRH_USERNAME')
 def ossrhPassword = findProperty('OSSRH_PASSWORD')
 def signingKey = findProperty('SIGNING_KEY')
 def signingKeyPwd = findProperty('SIGNING_KEY_PWD')
-def libVersion = "1.0.4"
+
+/**
+ * IS_SNAPSHOT_RELEASE property will be automatically added to the root gradle.properties file by the CI pipeline, depending on the GitHub branch.
+ * A snapshot release is generated for every pull request merged or commit made into an epic branch.
+ */
+def isSnapshotRelease = findProperty('IS_SNAPSHOT_RELEASE') == 'true'
+def libVersion = isSnapshotRelease ? "${findProperty('VERSION_NAME')}-SNAPSHOT" : findProperty('VERSION_NAME')
 
 afterEvaluate {
     publishing {
@@ -45,7 +51,7 @@ afterEvaluate {
 
                 def releasesRepoUrl = "https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/"
                 def snapshotsRepoUrl = "https://s01.oss.sonatype.org/content/repositories/snapshots/"
-                url = version.endsWith('SNAPSHOT') ? snapshotsRepoUrl : releasesRepoUrl
+                url = libVersion.endsWith('SNAPSHOT') ? snapshotsRepoUrl : releasesRepoUrl
 
                 credentials {
                     username ossrhUsername

--- a/lib/src/main/AndroidManifest.xml
+++ b/lib/src/main/AndroidManifest.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+<manifest>
 
 </manifest>

--- a/lib/src/main/java/com/what3words/components/maps/extensions/DomainExtensions.kt
+++ b/lib/src/main/java/com/what3words/components/maps/extensions/DomainExtensions.kt
@@ -4,10 +4,10 @@ import com.google.maps.android.collections.PolylineManager
 import com.what3words.androidwrapper.What3WordsAndroidWrapper
 import com.what3words.javawrapper.response.ConvertTo3WA
 import com.what3words.javawrapper.response.ConvertToCoordinates
+import com.what3words.javawrapper.response.Coordinates
 import com.what3words.javawrapper.response.Line
 import com.what3words.javawrapper.response.Square
 import com.what3words.javawrapper.response.Suggestion
-import com.what3words.javawrapper.response.Coordinates
 import com.what3words.javawrapper.response.SuggestionWithCoordinates
 
 //To be moved to core library extensions?

--- a/lib/src/main/java/com/what3words/components/maps/views/W3WGoogleMapFragment.kt
+++ b/lib/src/main/java/com/what3words/components/maps/views/W3WGoogleMapFragment.kt
@@ -19,13 +19,11 @@ import com.google.android.gms.maps.SupportMapFragment
 import com.google.android.gms.maps.model.CameraPosition
 import com.google.android.gms.maps.model.LatLng
 import com.google.android.gms.maps.model.LatLngBounds
-import com.google.android.gms.maps.model.MapStyleOptions
-import com.google.maps.android.data.Renderer
 import com.what3words.androidwrapper.What3WordsAndroidWrapper
 import com.what3words.androidwrapper.What3WordsV3
-import com.what3words.components.maps.wrappers.GridColor
 import com.what3words.components.maps.models.W3WMarkerColor
 import com.what3words.components.maps.models.W3WZoomOption
+import com.what3words.components.maps.wrappers.GridColor
 import com.what3words.components.maps.wrappers.W3WGoogleMapsWrapper
 import com.what3words.javawrapper.response.APIResponse
 import com.what3words.javawrapper.response.Suggestion
@@ -287,6 +285,10 @@ class W3WGoogleMapFragment() : W3WMapFragment, Fragment(), OnMapReadyCallback,
             })
         }
 
+        /**
+         * Handle zoom option for a [LatLng] with multiple zoom options which will use the zoom level
+         * if it's provided or the default zoom level.
+         */
         private fun handleZoomOption(latLng: LatLng, zoomOption: W3WZoomOption, zoom: Float?) {
             when (zoomOption) {
                 W3WZoomOption.NONE -> {}
@@ -307,6 +309,10 @@ class W3WGoogleMapFragment() : W3WMapFragment, Fragment(), OnMapReadyCallback,
             }
         }
 
+        /**
+         * Handle zoom option for a [LatLngBounds] rectangle with multiple zoom options which will use the zoom level
+         * if it's provided or the default zoom level.
+         */
         private fun handleZoomOption(latLng: LatLngBounds, zoomOption: W3WZoomOption) {
             when (zoomOption) {
                 W3WZoomOption.NONE -> {}

--- a/lib/src/main/java/com/what3words/components/maps/views/W3WMap.kt
+++ b/lib/src/main/java/com/what3words/components/maps/views/W3WMap.kt
@@ -1,9 +1,9 @@
 package com.what3words.components.maps.views
 
 import androidx.core.util.Consumer
-import com.what3words.components.maps.wrappers.GridColor
 import com.what3words.components.maps.models.W3WMarkerColor
 import com.what3words.components.maps.models.W3WZoomOption
+import com.what3words.components.maps.wrappers.GridColor
 import com.what3words.javawrapper.response.APIResponse
 import com.what3words.javawrapper.response.Suggestion
 import com.what3words.javawrapper.response.SuggestionWithCoordinates

--- a/lib/src/main/java/com/what3words/components/maps/views/W3WMapboxMapFragment.kt
+++ b/lib/src/main/java/com/what3words/components/maps/views/W3WMapboxMapFragment.kt
@@ -266,6 +266,10 @@ class W3WMapboxMapFragment() : W3WMapFragment, Fragment() {
             })
         }
 
+        /**
+         * Handle zoom option for a [Point] with multiple zoom options which will use the zoom level
+         * if it's provided or the default zoom level.
+         */
         private fun handleZoomOption(latLng: Point, zoomOption: W3WZoomOption, zoomLevel: Float?) {
             when (zoomOption) {
                 W3WZoomOption.NONE -> {}
@@ -286,6 +290,10 @@ class W3WMapboxMapFragment() : W3WMapFragment, Fragment() {
             }
         }
 
+        /**
+         * Handle zoom option for a list of [Point] with multiple zoom options which will use the zoom level
+         * if it's provided or the default zoom level.
+         */
         private fun handleZoomOption(latLng: List<Point>, zoomOption: W3WZoomOption) {
             when (zoomOption) {
                 W3WZoomOption.NONE -> {}

--- a/lib/src/main/java/com/what3words/components/maps/wrappers/W3WGoogleMapsWrapper.kt
+++ b/lib/src/main/java/com/what3words/components/maps/wrappers/W3WGoogleMapsWrapper.kt
@@ -60,7 +60,6 @@ class W3WGoogleMapsWrapper(
     private val wrapper: What3WordsAndroidWrapper,
     private val dispatchers: DispatcherProvider = DefaultDispatcherProvider()
 ) : W3WMapWrapper {
-    private var test: ((SuggestionWithCoordinates?) -> Unit)? = null
     private var zoomSwitchLevel: Float = DEFAULT_ZOOM_SWITCH_LEVEL
     private var isDarkMode: Boolean = false
 

--- a/lib/src/main/java/com/what3words/components/maps/wrappers/W3WGoogleMapsWrapper.kt
+++ b/lib/src/main/java/com/what3words/components/maps/wrappers/W3WGoogleMapsWrapper.kt
@@ -1,35 +1,39 @@
 package com.what3words.components.maps.wrappers
 
-import android.content.BroadcastReceiver
 import android.content.Context
-import android.content.Intent
-import android.content.IntentFilter
 import android.graphics.Bitmap
 import android.graphics.Canvas
 import android.graphics.Point
-import android.location.LocationManager
 import androidx.annotation.DrawableRes
 import androidx.core.content.ContextCompat
+import androidx.core.util.Consumer
 import com.google.android.gms.maps.GoogleMap
 import com.google.android.gms.maps.model.BitmapDescriptor
 import com.google.android.gms.maps.model.BitmapDescriptorFactory
 import com.google.android.gms.maps.model.GroundOverlayOptions
 import com.google.android.gms.maps.model.LatLng
 import com.google.android.gms.maps.model.LatLngBounds
+import com.google.android.gms.maps.model.MapStyleOptions
 import com.google.android.gms.maps.model.MarkerOptions
 import com.google.android.gms.maps.model.PolylineOptions
 import com.google.maps.android.collections.GroundOverlayManager
 import com.google.maps.android.collections.MarkerManager
 import com.google.maps.android.collections.PolylineManager
+import com.what3words.androidwrapper.What3WordsAndroidWrapper
 import com.what3words.androidwrapper.helpers.DefaultDispatcherProvider
 import com.what3words.androidwrapper.helpers.DispatcherProvider
+import com.what3words.components.maps.extensions.computeHorizontalLines
+import com.what3words.components.maps.extensions.computeVerticalLines
 import com.what3words.components.maps.extensions.contains
+import com.what3words.components.maps.extensions.generateUniqueId
 import com.what3words.components.maps.extensions.main
+import com.what3words.components.maps.models.DarkModeStyle
 import com.what3words.components.maps.models.SuggestionWithCoordinatesAndStyle
 import com.what3words.components.maps.models.W3WMarkerColor
 import com.what3words.components.maps.models.toCircle
 import com.what3words.components.maps.models.toGridFill
 import com.what3words.components.maps.models.toPin
+import com.what3words.components.maps.views.W3WMap
 import com.what3words.javawrapper.request.BoundingBox
 import com.what3words.javawrapper.request.Coordinates
 import com.what3words.javawrapper.response.APIResponse
@@ -40,20 +44,6 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
-import androidx.core.util.Consumer
-import com.google.android.gms.maps.model.MapStyleOptions
-import com.mapbox.maps.MapboxMap
-import com.mapbox.maps.RenderedQueryGeometry
-import com.mapbox.maps.RenderedQueryOptions
-import com.mapbox.maps.plugin.gestures.addOnMapClickListener
-import com.what3words.androidwrapper.What3WordsAndroidWrapper
-import com.what3words.components.maps.models.DarkModeStyle
-import com.what3words.components.maps.views.W3WMap
-import com.what3words.components.maps.extensions.computeHorizontalLines
-import com.what3words.components.maps.extensions.computeVerticalLines
-import com.what3words.components.maps.extensions.generateUniqueId
-import kotlinx.coroutines.channels.awaitClose
-import kotlinx.coroutines.flow.callbackFlow
 import kotlin.math.roundToInt
 
 /**
@@ -651,9 +641,9 @@ class W3WGoogleMapsWrapper(
     /** [getGridColorBasedOnZoomLevel] will get the grid color based on [GoogleMap.getCameraPosition] zoom. */
     private fun getGridSelectedBorderSizeBasedOnZoomLevel(zoom: Float = mapView.cameraPosition.zoom): Float {
         return when {
-            zoom < 19 -> context.resources.getDimension(R.dimen.grid_width_gone)
-            zoom >= 19 && zoom < 20 -> context.resources.getDimension(R.dimen.grid_selected_width_far)
-            zoom >= 20 && zoom < 22 -> context.resources.getDimension(R.dimen.grid_selected_width_middle)
+            zoom < zoomSwitchLevel -> context.resources.getDimension(R.dimen.grid_width_gone)
+            zoom >= zoomSwitchLevel && zoom < (zoomSwitchLevel + 1) -> context.resources.getDimension(R.dimen.grid_selected_width_far)
+            zoom >= (zoomSwitchLevel + 1) && zoom < (zoomSwitchLevel + 2) -> context.resources.getDimension(R.dimen.grid_selected_width_middle)
             else -> context.resources.getDimension(R.dimen.grid_selected_width_close)
         }
     }

--- a/lib/src/main/java/com/what3words/components/maps/wrappers/W3WMapBoxWrapper.kt
+++ b/lib/src/main/java/com/what3words/components/maps/wrappers/W3WMapBoxWrapper.kt
@@ -943,13 +943,13 @@ class W3WMapBoxWrapper(
     /** [getGridColorBasedOnZoomLevel] will get the grid color based on [MapboxMap.cameraState] zoom. */
     private fun getGridSelectedBorderSizeBasedOnZoomLevel(zoom: Double = mapView.cameraState.zoom): Double {
         return when {
-            zoom < 19 -> context.resources.getDimension(R.dimen.grid_width_mapbox_gone)
+            zoom < zoomSwitchLevel -> context.resources.getDimension(R.dimen.grid_width_mapbox_gone)
                 .toDouble()
 
-            zoom >= 19 && zoom < 20 -> context.resources.getDimension(R.dimen.grid_selected_width_mapbox_far)
+            zoom >= zoomSwitchLevel && zoom < (zoomSwitchLevel + 1) -> context.resources.getDimension(R.dimen.grid_selected_width_mapbox_far)
                 .toDouble()
 
-            zoom >= 20 && zoom < 21 -> context.resources.getDimension(R.dimen.grid_selected_width_mapbox_middle)
+            zoom >= (zoomSwitchLevel + 1) && zoom < (zoomSwitchLevel + 2) -> context.resources.getDimension(R.dimen.grid_selected_width_mapbox_middle)
                 .toDouble()
 
             else -> context.resources.getDimension(R.dimen.grid_selected_width_mapbox_close)

--- a/lib/src/main/java/com/what3words/components/maps/wrappers/W3WMapWrapper.kt
+++ b/lib/src/main/java/com/what3words/components/maps/wrappers/W3WMapWrapper.kt
@@ -3,8 +3,6 @@ package com.what3words.components.maps.wrappers
 import androidx.core.util.Consumer
 import com.google.android.gms.maps.GoogleMap
 import com.mapbox.maps.MapboxMap
-import com.what3words.androidwrapper.What3WordsAndroidWrapper
-import com.what3words.components.maps.models.SuggestionWithCoordinatesAndStyle
 import com.what3words.components.maps.models.W3WMarkerColor
 import com.what3words.components.maps.views.W3WMap
 import com.what3words.javawrapper.response.APIResponse

--- a/settings.gradle
+++ b/settings.gradle
@@ -24,6 +24,12 @@ dependencyResolutionManagement {
                 password = MAPBOX_DOWNLOADS_TOKEN
             }
         }
+        maven {
+            url "https://s01.oss.sonatype.org/content/repositories/comwhat3words-1446"
+        }
+        maven {
+            url "https://s01.oss.sonatype.org/content/repositories/snapshots/"
+        }
     }
 }
 rootProject.name = "w3w-android-components-maps"


### PR DESCRIPTION
- update mapbox 10.18.3
- Update Google Maps to 19.0.0 (Legacy mode on level 2 for grid above buildings)
- fixed issues with Mapbox query features; it crashed when updated to the latest, and to query if a marker was clicked needs to be on map click and handled by dev, which makes sense. 
- changed zoom levels to 19 (18 was wrong)
- fixed issue with mapbox multiple selected w3w at the same time. 
- AGP 8.5.0
- SDK 34 compatible