### PR TITLE
Refactor CameraState update mechanism

### DIFF
--- a/lib-compose/build.gradle.kts
+++ b/lib-compose/build.gradle.kts
@@ -80,7 +80,7 @@ dependencies {
     implementation(libs.kotlinx.coroutines.core)
     implementation(libs.kotlinx.coroutines.android)
     testImplementation(libs.kotlinx.coroutines.test)
-    implementation(libs.kotlinx.collections.immutable)
+    api(libs.kotlinx.collections.immutable)
 
     // Compose
     implementation(platform(libs.androidx.compose.bom))

--- a/lib-compose/src/main/java/com/what3words/components/compose/maps/providers/googlemap/W3WGoogleMap.kt
+++ b/lib-compose/src/main/java/com/what3words/components/compose/maps/providers/googlemap/W3WGoogleMap.kt
@@ -24,12 +24,10 @@ import com.what3words.components.compose.maps.state.camera.W3WGoogleCameraState
 import com.what3words.core.types.geometry.W3WCoordinates
 import com.what3words.core.types.geometry.W3WRectangle
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.conflate
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.withContext
-import kotlin.math.abs
 import kotlin.math.roundToInt
 
 /**
@@ -86,12 +84,6 @@ fun W3WGoogleMap(
         snapshotFlow { cameraPositionState.position to cameraPositionState.projection }
             .conflate()
             .onEach { (position, projection) ->
-                val significantChange = isSignificantChange(position, lastProcessedPosition)
-                if (significantChange) {
-                    delay(300)
-                } else {
-                    delay(500)
-                }
                 projection?.let {
                     updateGridBound(projection, mapConfig.gridLineConfig) { newBound ->
                         lastProcessedPosition = position
@@ -116,17 +108,6 @@ fun W3WGoogleMap(
         W3WGoogleMapDrawer(state = state, mapConfig, onMarkerClicked)
         content?.invoke()
     }
-}
-
-private fun isSignificantChange(
-    newPosition: com.google.android.gms.maps.model.CameraPosition,
-    lastPosition: com.google.android.gms.maps.model.CameraPosition
-): Boolean {
-    val latDiff = abs(newPosition.target.latitude - lastPosition.target.latitude)
-    val lngDiff = abs(newPosition.target.longitude - lastPosition.target.longitude)
-    val zoomDiff = abs(newPosition.zoom - lastPosition.zoom)
-
-    return latDiff > 0.01 || lngDiff > 0.01 || zoomDiff > 0.5
 }
 
 private suspend fun updateGridBound(

--- a/lib-compose/src/main/java/com/what3words/components/compose/maps/providers/mapbox/W3WMapBox.kt
+++ b/lib-compose/src/main/java/com/what3words/components/compose/maps/providers/mapbox/W3WMapBox.kt
@@ -8,7 +8,6 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Modifier
-import com.mapbox.maps.CameraState
 import com.mapbox.maps.MapView
 import com.mapbox.maps.MapboxMap
 import com.mapbox.maps.extension.compose.MapEffect
@@ -27,12 +26,9 @@ import com.what3words.components.compose.maps.state.camera.W3WCameraState
 import com.what3words.components.compose.maps.state.camera.W3WMapboxCameraState
 import com.what3words.core.types.geometry.W3WCoordinates
 import com.what3words.core.types.geometry.W3WRectangle
-import kotlinx.coroutines.delay
-import kotlinx.coroutines.flow.conflate
 import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
-import kotlin.math.abs
 
 /**
  * A composable function that displays a What3Words (W3W) map using the Mapbox Maps SDK for Android.
@@ -67,16 +63,8 @@ fun W3WMapBox(
 
     LaunchedEffect(mapViewportState) {
         snapshotFlow { mapViewportState.cameraState }
-            .conflate()
             .filterNotNull()
             .onEach { currentCameraState ->
-                val significantChange =
-                    isSignificantChange(currentCameraState, lastProcessedCameraState)
-                if (significantChange) {
-                    delay(300)
-                } else {
-                    delay(500)
-                }
                 mapView?.mapboxMap?.let { mapboxMap ->
                     updateGridBound(
                         mapboxMap,
@@ -146,21 +134,6 @@ fun W3WMapBox(
         W3WMapBoxDrawer(state, mapConfig, onMarkerClicked)
         content?.invoke()
     }
-}
-
-private fun isSignificantChange(
-    newCameraState: CameraState,
-    lastCameraState: CameraState?
-): Boolean {
-    if (lastCameraState == null) {
-        return true
-    }
-
-    val latDiff = abs(newCameraState.center.latitude() - lastCameraState.center.latitude())
-    val lngDiff = abs(newCameraState.center.longitude() - lastCameraState.center.longitude())
-    val zoomDiff = abs(newCameraState.zoom - lastCameraState.zoom)
-
-    return latDiff > 0.01 || lngDiff > 0.01 || zoomDiff > 0.5
 }
 
 private fun updateGridBound(


### PR DESCRIPTION
- Ensures the internal W3WCameraState updates continuously to reflect changes in the GoogleMap or MapBox camera state.
- Relocates the debounce mechanism for grid line calculations to W3WMapManager, centralizing the logic for better control and consistency.
- Refactors W3WMapManager to improve readability and maintainability by breaking down large functions into smaller functions.
