### PR TITLE
Remove padding for zoom-in marker

### DIFF
--- a/lib-compose/src/main/java/com/what3words/components/compose/maps/utils/BitmapUtils.kt
+++ b/lib-compose/src/main/java/com/what3words/components/compose/maps/utils/BitmapUtils.kt
@@ -62,7 +62,8 @@ fun getFillGridMarkerBitmap(
         ),
         size,
         size,
-        scale
+        scale,
+        0
     )
 }
 


### PR DESCRIPTION
- Set padding of getFillGridMarkerBitmap() to 0 to fill the square