### PR TITLE
Fix Mapbox raster marker colors and night visibility

### DIFF
--- a/lib-compose/src/main/java/com/what3words/components/compose/maps/providers/mapbox/W3WMapBoxDrawer.kt
+++ b/lib-compose/src/main/java/com/what3words/components/compose/maps/providers/mapbox/W3WMapBoxDrawer.kt
@@ -484,7 +484,7 @@ private fun DrawZoomInMarkers(
                 },
                 rasterLayerState = remember {
                     RasterLayerState().apply {
-                        rasterContrast = DoubleValue(1.0)
+                        rasterEmissiveStrength = DoubleValue(1.0)
                     }
                 }
             )


### PR DESCRIPTION
We previously used `rasterContrast` as a shortcut to implement the marker background color in night mode (it actually coincidentally worked for some colors). The proper solution is to use `rasterEmissiveStrength`. For more information, you can read here: https://docs.mapbox.com/map-styles/standard/guides/#emissive-strength--custom-layers

The video below also shows the current progress of the refactor in the core app 😉

[Screen_recording_20251120_050353.webm](https://github.com/user-attachments/assets/f0e0573d-e19b-4627-ab9a-4f2cd20e6f5a)