### PR TITLE
Add fallback for excessive map padding

### DIFF
--- a/lib-compose/src/main/java/com/what3words/components/compose/maps/providers/mapbox/W3WMapBox.kt
+++ b/lib-compose/src/main/java/com/what3words/components/compose/maps/providers/mapbox/W3WMapBox.kt
@@ -9,6 +9,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Modifier
+import android.util.Log
 import com.mapbox.common.toValue
 import com.mapbox.maps.CameraBoundsOptions
 import com.mapbox.maps.CameraOptions
@@ -43,6 +44,9 @@ import kotlinx.coroutines.flow.onEach
 private const val MAPBOX_MIN_ZOOM_LEVEL = 3.0
 private const val MAPBOX_MAX_ZOOM_PITCH = 60.0
 private const val MAPBOX_DEFAULT_CAMERA_PADDING = 10.0
+// This is used to calculate the padding for the camera when the user's padding is too large.
+// It ensures that at least 1/3 of the map width is available for the content.
+private const val FALLBACK_PADDING_RATIO = 3
 
 /**
  * A composable function that displays a What3Words (W3W) map using the Mapbox Maps SDK for Android.
@@ -126,14 +130,25 @@ fun W3WMapBox(
             mapView?.let { mapView ->
                 mapView.mapboxMap.also { map ->
                     // Set the camera based on coordinates with individual padding for each side
+                    val mapWidth = map.getSize().width.toDouble()
+                    val targetPadding = state.cameraState.cameraPadding.toDouble()
+                    // If the target padding is too large (taking up more than the full width),
+                    // fallback to using a portion of the width as padding to ensure content visibility.
+                    val padding = if (targetPadding * 2 >= mapWidth) {
+                        Log.w("W3WMapBox", "The padding provided is too large for the map width. Falling back to using 1/$FALLBACK_PADDING_RATIO of the map width as padding.")
+                        mapWidth / FALLBACK_PADDING_RATIO
+                    } else {
+                        targetPadding
+                    }
+
                     map.cameraForCoordinates(
                         points,
                         CameraOptions.Builder().build(),
                         EdgeInsets(
                             0.0,
-                            state.cameraState.cameraPadding.toDouble(),
+                            padding,
                             0.0,
-                            state.cameraState.cameraPadding.toDouble()
+                            padding
                         ),
                         null,
                         null


### PR DESCRIPTION
This PR fixes a crash when moving the camera to multiple coordinates with padding, where the combined padding can exceed the map size and cause cameraForCoordinates to fail.

Example usage:
```
cameraState?.moveToPosition(
            listLatLng = coordinates,
            padding = maxOf(
                mapVisibleAreaPadding.start,
                mapVisibleAreaPadding.top,
                mapVisibleAreaPadding.end,
                mapVisibleAreaPadding.bottom
            ),
        )
```

Example error without this PR:
`[maps-core]: Failed to calculate cameraForCoordinates: the combined padding exceeds the map size. Coordinates padding is {"left": 420, "right": 420, "top": 0, "bottom": 0}, camera padding is {"left": 0, "right": 0, "top": 0, "bottom": 0}, map size is {"width": 840, "height": 1203}`