### PR TITLE
Support unit metric to MyLocationButton

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -23,5 +23,5 @@ android.nonTransitiveRClass=true
 kotlin.code.style=official
 android.nonFinalResIds=false
 LIBRARY_VERSION=2.1.0
-LIBRARY_COMPOSE_VERSION=2.1.2
+LIBRARY_COMPOSE_VERSION=2.1.3
 MAPBOX_DOWNLOADS_TOKEN = "YOUR_MAPBOX_DOWNLOADS_TOKEN"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -45,7 +45,7 @@ googleMapPlayService = "19.0.0"
 
 #What3words Library
 what3wordsWrapper = "4.0.3"
-what3wordsDesignLibrary = "2.0.6"
+what3wordsDesignLibrary = "2.0.9"
 
 #Maven Publish
 dokka = "2.0.0"

--- a/lib-compose/src/main/java/com/what3words/components/compose/maps/W3WMapDefaults.kt
+++ b/lib-compose/src/main/java/com/what3words/components/compose/maps/W3WMapDefaults.kt
@@ -7,8 +7,6 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
-import com.what3words.components.compose.maps.MapProvider.GOOGLE_MAP
-import com.what3words.components.compose.maps.MapProvider.MAPBOX
 import com.what3words.components.compose.maps.W3WMapDefaults.defaultMarkerColor
 import com.what3words.components.compose.maps.models.W3WMarkerColor
 import com.what3words.core.types.geometry.W3WCoordinates
@@ -133,6 +131,7 @@ object W3WMapDefaults {
         val isMyLocationFeatureEnabled: Boolean,
         val shouldSelectOnMyLocationClicked: Boolean,
         val isRecallFeatureEnabled: Boolean,
+        val unitMetric: DistanceUnit = DistanceUnit.METER
     )
 
     /**
@@ -260,13 +259,15 @@ object W3WMapDefaults {
         isMapSwitchFeatureEnabled: Boolean = true,
         isMyLocationFeatureEnabled: Boolean = true,
         shouldSelectOnMyLocationClicked: Boolean = true,
-        isRecallFeatureEnabled: Boolean = false
+        isRecallFeatureEnabled: Boolean = false,
+        unitMetric: DistanceUnit = DistanceUnit.METER
     ): ButtonConfig {
         return ButtonConfig(
             isMapSwitchFeatureEnabled = isMapSwitchFeatureEnabled,
             isMyLocationFeatureEnabled = isMyLocationFeatureEnabled,
             shouldSelectOnMyLocationClicked = shouldSelectOnMyLocationClicked,
-            isRecallFeatureEnabled = isRecallFeatureEnabled
+            isRecallFeatureEnabled = isRecallFeatureEnabled,
+            unitMetric = unitMetric
         )
     }
 
@@ -398,4 +399,9 @@ object W3WMapDefaults {
             selectedColor = selectedColor
         )
     }
+}
+
+enum class DistanceUnit(val unit: String) {
+    METER("m"),
+    FEET("ft")
 }

--- a/lib-compose/src/main/java/com/what3words/components/compose/maps/W3WMapDefaults.kt
+++ b/lib-compose/src/main/java/com/what3words/components/compose/maps/W3WMapDefaults.kt
@@ -10,6 +10,7 @@ import androidx.compose.ui.unit.dp
 import com.what3words.components.compose.maps.W3WMapDefaults.defaultMarkerColor
 import com.what3words.components.compose.maps.models.W3WMarkerColor
 import com.what3words.core.types.geometry.W3WCoordinates
+import com.what3words.design.library.ui.models.DisplayUnits
 import com.what3words.design.library.ui.theme.colors_blue_20
 import com.what3words.design.library.ui.theme.colors_blue_99
 import com.what3words.design.library.ui.theme.colors_grey_100
@@ -131,7 +132,7 @@ object W3WMapDefaults {
         val isMyLocationFeatureEnabled: Boolean,
         val shouldSelectOnMyLocationClicked: Boolean,
         val isRecallFeatureEnabled: Boolean,
-        val unitMetric: DistanceUnit = DistanceUnit.METER
+        val displayUnit: DisplayUnits = DisplayUnits.METRIC
     )
 
     /**
@@ -260,14 +261,14 @@ object W3WMapDefaults {
         isMyLocationFeatureEnabled: Boolean = true,
         shouldSelectOnMyLocationClicked: Boolean = true,
         isRecallFeatureEnabled: Boolean = false,
-        unitMetric: DistanceUnit = DistanceUnit.METER
+        displayUnit: DisplayUnits = DisplayUnits.METRIC
     ): ButtonConfig {
         return ButtonConfig(
             isMapSwitchFeatureEnabled = isMapSwitchFeatureEnabled,
             isMyLocationFeatureEnabled = isMyLocationFeatureEnabled,
             shouldSelectOnMyLocationClicked = shouldSelectOnMyLocationClicked,
             isRecallFeatureEnabled = isRecallFeatureEnabled,
-            unitMetric = unitMetric
+            displayUnit = displayUnit
         )
     }
 
@@ -399,9 +400,4 @@ object W3WMapDefaults {
             selectedColor = selectedColor
         )
     }
-}
-
-enum class DistanceUnit(val unit: String) {
-    METER("m"),
-    FEET("ft")
 }

--- a/lib-compose/src/main/java/com/what3words/components/compose/maps/buttons/MapButtons.kt
+++ b/lib-compose/src/main/java/com/what3words/components/compose/maps/buttons/MapButtons.kt
@@ -107,14 +107,14 @@ internal fun MapButtons(
         if (buttonConfig.isMyLocationFeatureEnabled && buttonState.isMyLocationButtonVisible) {
             MyLocationButton(
                 layoutConfig = layoutConfig.locationButtonLayoutConfig,
-                accuracyDistanceInMeter = buttonState.accuracyDistance.toInt(),
+                accuracyDistanceInMeter = buttonState.accuracyDistance,
                 isButtonEnabled = buttonState.isMyLocationButtonEnabled,
                 locationStatus = buttonState.locationStatus,
                 colors = locationButtonColor,
                 onMyLocationClicked = onMyLocationClicked,
                 resourceString = resourceString,
                 contentDescription = contentDescription,
-                unitMetric = buttonConfig.unitMetric
+                displayUnit = buttonConfig.displayUnit
             )
         }
         if (buttonConfig.isMapSwitchFeatureEnabled && buttonState.isMapSwitchButtonVisible) {

--- a/lib-compose/src/main/java/com/what3words/components/compose/maps/buttons/MapButtons.kt
+++ b/lib-compose/src/main/java/com/what3words/components/compose/maps/buttons/MapButtons.kt
@@ -107,13 +107,14 @@ internal fun MapButtons(
         if (buttonConfig.isMyLocationFeatureEnabled && buttonState.isMyLocationButtonVisible) {
             MyLocationButton(
                 layoutConfig = layoutConfig.locationButtonLayoutConfig,
-                accuracyDistance = buttonState.accuracyDistance.toInt(),
+                accuracyDistanceInMeter = buttonState.accuracyDistance.toInt(),
                 isButtonEnabled = buttonState.isMyLocationButtonEnabled,
                 locationStatus = buttonState.locationStatus,
                 colors = locationButtonColor,
                 onMyLocationClicked = onMyLocationClicked,
                 resourceString = resourceString,
                 contentDescription = contentDescription,
+                unitMetric = buttonConfig.unitMetric
             )
         }
         if (buttonConfig.isMapSwitchFeatureEnabled && buttonState.isMapSwitchButtonVisible) {

--- a/lib-compose/src/main/java/com/what3words/components/compose/maps/buttons/MapSwitchButton.kt
+++ b/lib-compose/src/main/java/com/what3words/components/compose/maps/buttons/MapSwitchButton.kt
@@ -40,7 +40,7 @@ internal fun MapSwitchButton(
     contentDescription: W3WMapButtonsDefault.ContentDescription = W3WMapButtonsDefault.defaultContentDescription(),
     onMapTypeChange: (W3WMapType) -> Unit
 ) {
-    var mapType by remember { mutableStateOf(w3wMapType) }
+    var mapType by remember(w3wMapType) { mutableStateOf(w3wMapType) }
     IconButton(
         modifier = modifier
             .padding(layoutConfig.buttonPadding)

--- a/lib-compose/src/main/java/com/what3words/components/compose/maps/buttons/MyLocationButton.kt
+++ b/lib-compose/src/main/java/com/what3words/components/compose/maps/buttons/MyLocationButton.kt
@@ -39,17 +39,18 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
+import com.what3words.components.compose.maps.DistanceUnit
 import com.what3words.components.compose.maps.state.LocationStatus
 import com.what3words.components.compose.maps.utils.ImmediateAnimatedVisibility
 import com.what3words.design.library.ui.theme.W3WTheme
 import com.what3words.map.components.compose.R
 import kotlinx.coroutines.delay
+import kotlin.math.roundToInt
 
 const val SAFE_ACCURACY_DISTANCE = 100
 const val WARNING_ACCURACY_DISTANCE = 200
-const val METER = "m"
-const val FEET = "ft"
 const val ACCURACY_VISIBLE_TIME = 3000L
+private const val METERS_TO_FT_RATIO = 3.2808399
 
 private enum class SearchIconState {
     ICON_ONE,
@@ -60,10 +61,10 @@ private enum class SearchIconState {
  * A composable function to display a "Find My Location" button.
  *
  * @param modifier The modifier for the button.
- * @param accuracyDistance The accuracy of the current location in meters.
+ * @param accuracyDistanceInMeter The accuracy of the current location in meters.
  * @param isButtonEnabled Whether the location button is enabled or not.
  * @param locationStatus The status of the location service.
- * @param unitMetrics The unit of accuracy distance, default is "m".
+ * @param unitMetric The unit of accuracy distance, default is "m".
  * @param layoutConfig Configuration for the button's layout, including positioning, size, and other layout properties. Defaults to [W3WMapButtonsDefault.defaultLocationButtonConfig].
  * @param colors Defines the color scheme of the location button, such as background and icon colors. Defaults to [W3WMapButtonsDefault.defaultLocationButtonColor].
  * @param resourceString The resource string for the button, default is [W3WMapButtonsDefault.defaultResourceString].
@@ -72,16 +73,16 @@ private enum class SearchIconState {
  */
 @Composable
 internal fun MyLocationButton(
-    modifier: Modifier = Modifier,
-    accuracyDistance: Int,
+    accuracyDistanceInMeter: Int,
     isButtonEnabled: Boolean,
     locationStatus: LocationStatus,
-    unitMetrics: String = METER,
+    onMyLocationClicked: () -> Unit,
+    modifier: Modifier = Modifier,
+    unitMetric: DistanceUnit = DistanceUnit.METER,
     layoutConfig: W3WMapButtonsDefault.LocationButtonLayoutConfig = W3WMapButtonsDefault.defaultLocationButtonConfig(),
     colors: W3WMapButtonsDefault.LocationButtonColor = W3WMapButtonsDefault.defaultLocationButtonColor(),
     resourceString: W3WMapButtonsDefault.ResourceString = W3WMapButtonsDefault.defaultResourceString(),
-    contentDescription: W3WMapButtonsDefault.ContentDescription = W3WMapButtonsDefault.defaultContentDescription(),
-    onMyLocationClicked: () -> Unit
+    contentDescription: W3WMapButtonsDefault.ContentDescription = W3WMapButtonsDefault.defaultContentDescription()
 ) {
 
     var isShowingAccuracy by remember { mutableStateOf(false) }
@@ -161,7 +162,11 @@ internal fun MyLocationButton(
                         .padding(start = 12.dp, end = 4.dp)
                 ) {
                     Text(
-                        text = resourceString.accuracyMessage.format(accuracyDistance, unitMetrics),
+                        text = toFormattedDistance(
+                            resourceString.accuracyMessage,
+                            accuracyDistanceInMeter,
+                            unitMetric
+                        ),
                         style = layoutConfig.accuracyTextStyle,
                         color = colors.accuracyTextColor,
                         maxLines = 1 // Prevent text overflow
@@ -202,10 +207,10 @@ internal fun MyLocationButton(
                         modifier = Modifier.size(layoutConfig.locationIconSize)
                     )
                 }
-                if (accuracyDistance >= SAFE_ACCURACY_DISTANCE) {
+                if (accuracyDistanceInMeter >= SAFE_ACCURACY_DISTANCE) {
                     WarningIndicator(
                         modifier = Modifier.align(Alignment.TopEnd),
-                        accuracyDistance = accuracyDistance,
+                        accuracyDistance = accuracyDistanceInMeter,
                         buttonConfig = layoutConfig,
                         colors = colors,
                         contentDescription = contentDescription
@@ -248,6 +253,23 @@ private fun WarningIndicator(
     }
 }
 
+private fun toFormattedDistance(
+    accuracyMessage: String,
+    distanceInMeter: Int,
+    unitMetric: DistanceUnit
+): String {
+    val value = when (unitMetric) {
+        DistanceUnit.METER -> distanceInMeter
+        DistanceUnit.FEET -> (distanceInMeter * METERS_TO_FT_RATIO).roundToInt()
+    }
+    return try {
+        accuracyMessage.format(value, unitMetric.unit)
+    } catch (_: Exception) {
+        // Fallback or log error if format string is invalid
+        "$value ${unitMetric.unit}"
+    }
+}
+
 @Preview(uiMode = Configuration.UI_MODE_NIGHT_YES)
 @Preview(uiMode = Configuration.UI_MODE_NIGHT_NO)
 @Composable
@@ -256,9 +278,9 @@ private fun A1() {
         MyLocationButton(
             modifier = Modifier,
             onMyLocationClicked = {},
-            accuracyDistance = 0,
+            accuracyDistanceInMeter = 0,
             isButtonEnabled = true,
-            unitMetrics = METER,
+            unitMetric = DistanceUnit.METER,
             locationStatus = LocationStatus.SEARCHING
         )
     }
@@ -272,9 +294,9 @@ private fun A2() {
         MyLocationButton(
             modifier = Modifier,
             onMyLocationClicked = {},
-            accuracyDistance = 0,
+            accuracyDistanceInMeter = 0,
             isButtonEnabled = true,
-            unitMetrics = METER,
+            unitMetric = DistanceUnit.METER,
             locationStatus = LocationStatus.INACTIVE
         )
     }
@@ -288,9 +310,9 @@ private fun A3() {
         MyLocationButton(
             modifier = Modifier,
             onMyLocationClicked = {},
-            accuracyDistance = 70,
+            accuracyDistanceInMeter = 70,
             isButtonEnabled = true,
-            unitMetrics = METER,
+            unitMetric = DistanceUnit.METER,
             locationStatus = LocationStatus.ACTIVE
         )
     }
@@ -304,9 +326,9 @@ private fun A4() {
         MyLocationButton(
             modifier = Modifier,
             onMyLocationClicked = {},
-            accuracyDistance = 120,
+            accuracyDistanceInMeter = 120,
             isButtonEnabled = true,
-            unitMetrics = METER,
+            unitMetric = DistanceUnit.METER,
             locationStatus = LocationStatus.ACTIVE
         )
     }
@@ -320,9 +342,9 @@ private fun A5() {
         MyLocationButton(
             modifier = Modifier,
             onMyLocationClicked = {},
-            accuracyDistance = 220,
+            accuracyDistanceInMeter = 220,
             isButtonEnabled = true,
-            unitMetrics = METER,
+            unitMetric = DistanceUnit.METER,
             locationStatus = LocationStatus.ACTIVE
         )
     }
@@ -337,9 +359,9 @@ private fun A6() {
             MyLocationButton(
                 modifier = Modifier,
                 onMyLocationClicked = {},
-                accuracyDistance = 220,
+                accuracyDistanceInMeter = 220,
                 isButtonEnabled = true,
-                unitMetrics = METER,
+                unitMetric = DistanceUnit.METER,
                 locationStatus = LocationStatus.ACTIVE
             )
         }

--- a/lib-compose/src/main/java/com/what3words/components/compose/maps/buttons/MyLocationButton.kt
+++ b/lib-compose/src/main/java/com/what3words/components/compose/maps/buttons/MyLocationButton.kt
@@ -34,23 +34,23 @@ import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.graphics.vector.rememberVectorPainter
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
-import com.what3words.components.compose.maps.DistanceUnit
 import com.what3words.components.compose.maps.state.LocationStatus
 import com.what3words.components.compose.maps.utils.ImmediateAnimatedVisibility
+import com.what3words.design.library.ui.models.DisplayUnits
+import com.what3words.design.library.ui.models.getAccuracyString
 import com.what3words.design.library.ui.theme.W3WTheme
 import com.what3words.map.components.compose.R
 import kotlinx.coroutines.delay
-import kotlin.math.roundToInt
 
 const val SAFE_ACCURACY_DISTANCE = 100
 const val WARNING_ACCURACY_DISTANCE = 200
 const val ACCURACY_VISIBLE_TIME = 3000L
-private const val METERS_TO_FT_RATIO = 3.2808399
 
 private enum class SearchIconState {
     ICON_ONE,
@@ -64,7 +64,7 @@ private enum class SearchIconState {
  * @param accuracyDistanceInMeter The accuracy of the current location in meters.
  * @param isButtonEnabled Whether the location button is enabled or not.
  * @param locationStatus The status of the location service.
- * @param unitMetric The unit of accuracy distance, default is "m".
+ * @param displayUnit The unit of accuracy distance, default is METRIC.
  * @param layoutConfig Configuration for the button's layout, including positioning, size, and other layout properties. Defaults to [W3WMapButtonsDefault.defaultLocationButtonConfig].
  * @param colors Defines the color scheme of the location button, such as background and icon colors. Defaults to [W3WMapButtonsDefault.defaultLocationButtonColor].
  * @param resourceString The resource string for the button, default is [W3WMapButtonsDefault.defaultResourceString].
@@ -73,17 +73,18 @@ private enum class SearchIconState {
  */
 @Composable
 internal fun MyLocationButton(
-    accuracyDistanceInMeter: Int,
+    accuracyDistanceInMeter: Float,
     isButtonEnabled: Boolean,
     locationStatus: LocationStatus,
     onMyLocationClicked: () -> Unit,
     modifier: Modifier = Modifier,
-    unitMetric: DistanceUnit = DistanceUnit.METER,
+    displayUnit: DisplayUnits = DisplayUnits.METRIC,
     layoutConfig: W3WMapButtonsDefault.LocationButtonLayoutConfig = W3WMapButtonsDefault.defaultLocationButtonConfig(),
     colors: W3WMapButtonsDefault.LocationButtonColor = W3WMapButtonsDefault.defaultLocationButtonColor(),
     resourceString: W3WMapButtonsDefault.ResourceString = W3WMapButtonsDefault.defaultResourceString(),
     contentDescription: W3WMapButtonsDefault.ContentDescription = W3WMapButtonsDefault.defaultContentDescription()
 ) {
+    val context = LocalContext.current
 
     var isShowingAccuracy by remember { mutableStateOf(false) }
     var searchingIconState by remember { mutableStateOf(SearchIconState.ICON_ONE) }
@@ -162,10 +163,11 @@ internal fun MyLocationButton(
                         .padding(start = 12.dp, end = 4.dp)
                 ) {
                     Text(
-                        text = toFormattedDistance(
-                            resourceString.accuracyMessage,
-                            accuracyDistanceInMeter,
-                            unitMetric
+                        text = resourceString.accuracyMessage.format(
+                            getAccuracyString(
+                                accuracyDistanceInMeter,
+                                displayUnit
+                            )
                         ),
                         style = layoutConfig.accuracyTextStyle,
                         color = colors.accuracyTextColor,
@@ -224,7 +226,7 @@ internal fun MyLocationButton(
 @Composable
 private fun WarningIndicator(
     modifier: Modifier,
-    accuracyDistance: Int,
+    accuracyDistance: Float,
     buttonConfig: W3WMapButtonsDefault.LocationButtonLayoutConfig,
     colors: W3WMapButtonsDefault.LocationButtonColor,
     contentDescription: W3WMapButtonsDefault.ContentDescription,
@@ -253,23 +255,6 @@ private fun WarningIndicator(
     }
 }
 
-private fun toFormattedDistance(
-    accuracyMessage: String,
-    distanceInMeter: Int,
-    unitMetric: DistanceUnit
-): String {
-    val value = when (unitMetric) {
-        DistanceUnit.METER -> distanceInMeter
-        DistanceUnit.FEET -> (distanceInMeter * METERS_TO_FT_RATIO).roundToInt()
-    }
-    return try {
-        accuracyMessage.format(value, unitMetric.unit)
-    } catch (_: Exception) {
-        // Fallback or log error if format string is invalid
-        "$value ${unitMetric.unit}"
-    }
-}
-
 @Preview(uiMode = Configuration.UI_MODE_NIGHT_YES)
 @Preview(uiMode = Configuration.UI_MODE_NIGHT_NO)
 @Composable
@@ -278,9 +263,8 @@ private fun A1() {
         MyLocationButton(
             modifier = Modifier,
             onMyLocationClicked = {},
-            accuracyDistanceInMeter = 0,
+            accuracyDistanceInMeter = 0f,
             isButtonEnabled = true,
-            unitMetric = DistanceUnit.METER,
             locationStatus = LocationStatus.SEARCHING
         )
     }
@@ -294,9 +278,8 @@ private fun A2() {
         MyLocationButton(
             modifier = Modifier,
             onMyLocationClicked = {},
-            accuracyDistanceInMeter = 0,
+            accuracyDistanceInMeter = 0f,
             isButtonEnabled = true,
-            unitMetric = DistanceUnit.METER,
             locationStatus = LocationStatus.INACTIVE
         )
     }
@@ -310,9 +293,8 @@ private fun A3() {
         MyLocationButton(
             modifier = Modifier,
             onMyLocationClicked = {},
-            accuracyDistanceInMeter = 70,
+            accuracyDistanceInMeter = 70f,
             isButtonEnabled = true,
-            unitMetric = DistanceUnit.METER,
             locationStatus = LocationStatus.ACTIVE
         )
     }
@@ -326,9 +308,8 @@ private fun A4() {
         MyLocationButton(
             modifier = Modifier,
             onMyLocationClicked = {},
-            accuracyDistanceInMeter = 120,
+            accuracyDistanceInMeter = 120f,
             isButtonEnabled = true,
-            unitMetric = DistanceUnit.METER,
             locationStatus = LocationStatus.ACTIVE
         )
     }
@@ -342,9 +323,8 @@ private fun A5() {
         MyLocationButton(
             modifier = Modifier,
             onMyLocationClicked = {},
-            accuracyDistanceInMeter = 220,
+            accuracyDistanceInMeter = 220f,
             isButtonEnabled = true,
-            unitMetric = DistanceUnit.METER,
             locationStatus = LocationStatus.ACTIVE
         )
     }
@@ -359,9 +339,8 @@ private fun A6() {
             MyLocationButton(
                 modifier = Modifier,
                 onMyLocationClicked = {},
-                accuracyDistanceInMeter = 220,
+                accuracyDistanceInMeter = 220f,
                 isButtonEnabled = true,
-                unitMetric = DistanceUnit.METER,
                 locationStatus = LocationStatus.ACTIVE
             )
         }

--- a/lib-compose/src/main/java/com/what3words/components/compose/maps/buttons/W3WMapButtonsDefault.kt
+++ b/lib-compose/src/main/java/com/what3words/components/compose/maps/buttons/W3WMapButtonsDefault.kt
@@ -346,11 +346,11 @@ object W3WMapButtonsDefault {
 
     /**
      * Creates default resource strings for buttons.
-     * @param accuracyMessage Format string for accuracy message. Default is "GPS Accuracy (%d%s)".
+     * @param accuracyMessage Format string for accuracy message. Default is "GPS Accuracy is %s".
      * @return [ResourceString] object with the specified strings.
      */
     fun defaultResourceString(
-        accuracyMessage: String = "GPS Accuracy (%d%s)"
+        accuracyMessage: String = "GPS Accuracy is %s"
     ): ResourceString {
         return ResourceString(
             accuracyMessage = accuracyMessage


### PR DESCRIPTION
Introduces a `DistanceUnit` enum (METER, FEET) to allow configuration of the distance unit displayed on the My Location button.

The `ButtonConfig` now includes a `unitMetric` property, which defaults to `METER`. This setting is passed down to the `MyLocationButton` to control whether the accuracy is displayed in meters or feet. The internal logic has been updated to handle the conversion and formatting.