### PR TITLE
Resolve W3WRectangle.id collision using high-precision hashing

### DIFF
--- a/lib-compose/src/main/java/com/what3words/components/compose/maps/extensions/DomainExtensions.kt
+++ b/lib-compose/src/main/java/com/what3words/components/compose/maps/extensions/DomainExtensions.kt
@@ -19,6 +19,14 @@ internal fun W3WRectangle.contains(coordinates: W3WCoordinates?): Boolean {
     else false
 }
 
+/**
+ * Generates a unique 64-bit ID using SplitMix64-based hash function.
+ * 
+ * Based on "Fast Splittable Pseudorandom Number Generators" (Steele et al., OOPSLA 2014)
+ * and java.util.SplittableRandom. Uses doubleToLongBits() for exact precision,
+ * XOR-shift-multiplication mixing for avalanche effect, and prime multipliers
+ * to prevent coordinate swap collisions.
+ */
 val W3WRectangle.id: Long
     get() {
         val sw = this.southwest
@@ -31,12 +39,37 @@ val W3WRectangle.id: Long
             throw IllegalArgumentException("Invalid longitude value: must be between -180 and 180")
         }
 
-        val swLatBits = (sw.lat * 1e6).toLong() and 0x7FFFFFFF
-        val swLngBits = (sw.lng * 1e6).toLong() and 0x7FFFFFFF
-        val neLatBits = (ne.lat * 1e6).toLong() and 0x7FFFFFFF
-        val neLngBits = (ne.lng * 1e6).toLong() and 0x7FFFFFFF
+        val swLat = java.lang.Double.doubleToLongBits(sw.lat)
+        val swLng = java.lang.Double.doubleToLongBits(sw.lng)
+        val neLat = java.lang.Double.doubleToLongBits(ne.lat)
+        val neLng = java.lang.Double.doubleToLongBits(ne.lng)
 
-        return (swLatBits shl 48) or (swLngBits shl 32) or (neLatBits shl 16) or neLngBits
+        var h1 = swLat * -7046029254386353131L
+        h1 = (h1 xor (h1 ushr 30)) * -4658895280553007687L
+        h1 = (h1 xor (h1 ushr 27)) * -7723592293110705685L
+        h1 = h1 xor (h1 ushr 31)
+
+        var h2 = swLng * -7046029254386353131L
+        h2 = (h2 xor (h2 ushr 30)) * -4658895280553007687L
+        h2 = (h2 xor (h2 ushr 27)) * -7723592293110705685L
+        h2 = h2 xor (h2 ushr 31)
+
+        var h3 = neLat * -7046029254386353131L
+        h3 = (h3 xor (h3 ushr 30)) * -4658895280553007687L
+        h3 = (h3 xor (h3 ushr 27)) * -7723592293110705685L
+        h3 = h3 xor (h3 ushr 31)
+
+        var h4 = neLng * -7046029254386353131L
+        h4 = (h4 xor (h4 ushr 30)) * -4658895280553007687L
+        h4 = (h4 xor (h4 ushr 27)) * -7723592293110705685L
+        h4 = h4 xor (h4 ushr 31)
+
+        var result = h1 + h2 * -4417273771661082387L + h3 * -2912652041462636481L + h4 * -744332891524214833L
+        result = (result xor (result ushr 33)) * -1110381560719973571L
+        result = (result xor (result ushr 33)) * -3956934367972663973L
+        result = result xor (result ushr 33)
+
+        return result
     }
 
 /** [computeVerticalLines] will compute vertical lines to work with [PolylineManager], it will invert every odd line to avoid diagonal connection.

--- a/lib-compose/src/test/java/com/what3words/map/components/compose/extensions/W3WRectangleIdTest.kt
+++ b/lib-compose/src/test/java/com/what3words/map/components/compose/extensions/W3WRectangleIdTest.kt
@@ -1,0 +1,199 @@
+package com.what3words.map.components.compose.extensions
+
+import com.what3words.components.compose.maps.extensions.id
+import com.what3words.core.types.geometry.W3WCoordinates
+import com.what3words.core.types.geometry.W3WRectangle
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Test
+
+class W3WRectangleIdTest {
+
+    @Test
+    fun `should generate unique IDs for different rectangles`() {
+        val rect1 = W3WRectangle(
+            southwest = W3WCoordinates(10.780078, 106.705424),
+            northeast = W3WCoordinates(10.780105, 106.705451)
+        )
+        val rect2 = W3WRectangle(
+            southwest = W3WCoordinates(10.780590, 106.705424),
+            northeast = W3WCoordinates(10.780617, 106.705451)
+        )
+
+        val id1 = rect1.id
+        val id2 = rect2.id
+
+        assertNotEquals("Different rectangles should have different IDs", id1, id2)
+    }
+
+    @Test
+    fun `should generate same ID for identical rectangles`() {
+        val rect1 = W3WRectangle(
+            southwest = W3WCoordinates(10.780078, 106.705424),
+            northeast = W3WCoordinates(10.780105, 106.705451)
+        )
+        val rect2 = W3WRectangle(
+            southwest = W3WCoordinates(10.780078, 106.705424),
+            northeast = W3WCoordinates(10.780105, 106.705451)
+        )
+
+        val id1 = rect1.id
+        val id2 = rect2.id
+
+        assertEquals("Identical rectangles should have the same ID", id1, id2)
+    }
+
+    @Test
+    fun `should generate different IDs for previously colliding rectangles - case 1`() {
+        // These two rectangles previously generated the same ID: 9222864837722059307
+        val rect1 = W3WRectangle(
+            southwest = W3WCoordinates(10.780078, 106.705424),
+            northeast = W3WCoordinates(10.780105, 106.705451)
+        )
+        val rect2 = W3WRectangle(
+            southwest = W3WCoordinates(10.780590, 106.705424),
+            northeast = W3WCoordinates(10.780617, 106.705451)
+        )
+
+        val id1 = rect1.id
+        val id2 = rect2.id
+
+        assertNotEquals("Previously colliding rectangles (case 1) should now have different IDs", id1, id2)
+    }
+
+    @Test
+    fun `should generate different IDs for previously colliding rectangles - case 2`() {
+        // These two rectangles previously generated the same ID: 9214139332489523810
+        val rect1 = W3WRectangle(
+            southwest = W3WCoordinates(10.780051, 106.705479),
+            northeast = W3WCoordinates(10.780078, 106.705506)
+        )
+        val rect2 = W3WRectangle(
+            southwest = W3WCoordinates(10.780563, 106.705479),
+            northeast = W3WCoordinates(10.780590, 106.705506)
+        )
+
+        val id1 = rect1.id
+        val id2 = rect2.id
+
+        assertNotEquals("Previously colliding rectangles (case 2) should now have different IDs", id1, id2)
+    }
+
+    @Test
+    fun `should generate different IDs for rectangles with very small coordinate differences`() {
+        val rect1 = W3WRectangle(
+            southwest = W3WCoordinates(54.672341, 89.467876),
+            northeast = W3WCoordinates(54.672351, 89.467886)
+        )
+        val rect2 = W3WRectangle(
+            southwest = W3WCoordinates(54.672342, 89.467875),
+            northeast = W3WCoordinates(54.672352, 89.467885)
+        )
+
+        val id1 = rect1.id
+        val id2 = rect2.id
+
+        assertNotEquals("Rectangles with micro-degree differences should have different IDs", id1, id2)
+    }
+
+    @Test
+    fun `should generate different IDs when sw and ne are swapped`() {
+        val rect1 = W3WRectangle(
+            southwest = W3WCoordinates(10.0, 100.0),
+            northeast = W3WCoordinates(10.001, 100.001)
+        )
+        val rect2 = W3WRectangle(
+            southwest = W3WCoordinates(10.001, 100.001),
+            northeast = W3WCoordinates(10.0, 100.0)
+        )
+
+        val id1 = rect1.id
+        val id2 = rect2.id
+
+        assertNotEquals("Swapped coordinates should produce different IDs", id1, id2)
+    }
+
+    @Test
+    fun `should generate different IDs for adjacent grid squares`() {
+        // Simulating adjacent w3w grid squares (3m x 3m approximately)
+        val rect1 = W3WRectangle(
+            southwest = W3WCoordinates(51.520847, -0.195521),
+            northeast = W3WCoordinates(51.520870, -0.195497)
+        )
+        val rect2 = W3WRectangle(
+            southwest = W3WCoordinates(51.520870, -0.195521),
+            northeast = W3WCoordinates(51.520893, -0.195497)
+        )
+
+        val id1 = rect1.id
+        val id2 = rect2.id
+
+        assertNotEquals("Adjacent grid squares should have different IDs", id1, id2)
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun `should throw exception for invalid latitude above range`() {
+        val rect = W3WRectangle(
+            southwest = W3WCoordinates(91.0, 100.0),
+            northeast = W3WCoordinates(10.0, 100.0)
+        )
+        rect.id
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun `should throw exception for invalid latitude below range`() {
+        val rect = W3WRectangle(
+            southwest = W3WCoordinates(-91.0, 100.0),
+            northeast = W3WCoordinates(10.0, 100.0)
+        )
+        rect.id
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun `should throw exception for invalid longitude above range`() {
+        val rect = W3WRectangle(
+            southwest = W3WCoordinates(10.0, 181.0),
+            northeast = W3WCoordinates(10.0, 100.0)
+        )
+        rect.id
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun `should throw exception for invalid longitude below range`() {
+        val rect = W3WRectangle(
+            southwest = W3WCoordinates(10.0, -181.0),
+            northeast = W3WCoordinates(10.0, 100.0)
+        )
+        rect.id
+    }
+
+    @Test
+    fun `should generate consistent IDs across multiple calls`() {
+        val rect = W3WRectangle(
+            southwest = W3WCoordinates(10.780078, 106.705424),
+            northeast = W3WCoordinates(10.780105, 106.705451)
+        )
+
+        val ids = (1..100).map { rect.id }
+        val uniqueIds = ids.toSet()
+
+        assertEquals("ID should be consistent across multiple calls", 1, uniqueIds.size)
+    }
+
+    @Test
+    fun `should generate unique IDs for large batch of random rectangles`() {
+        val rectangles = (1..1000).map { index ->
+            val lat = -90.0 + (index % 180) + (index * 0.000001)
+            val lng = -180.0 + (index % 360) + (index * 0.000001)
+            W3WRectangle(
+                southwest = W3WCoordinates(lat, lng),
+                northeast = W3WCoordinates(lat + 0.00003, lng + 0.00003)
+            )
+        }
+
+        val ids = rectangles.map { it.id }
+        val uniqueIds = ids.toSet()
+
+        assertEquals("All ${rectangles.size} rectangles should have unique IDs", rectangles.size, uniqueIds.size)
+    }
+}


### PR DESCRIPTION
Replace bit-packing approach with SplitMix64-based hash function that uses doubleToLongBits() for full precision coordinate encoding.

The previous implementation lost precision (1e6 multiplier) and caused frequent collisions when different rectangles shared lower 16-bit segments after masking and shifting.

New approach:
- Uses IEEE 754 bit representation for exact coordinate encoding
- Applies 3 rounds of bit mixing per coordinate (avalanche effect)
- Combines with unique prime multipliers to prevent swap collisions