### PR TITLE
Fix icons for map type hybrid and terrain

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -23,5 +23,5 @@ android.nonTransitiveRClass=true
 kotlin.code.style=official
 android.nonFinalResIds=false
 LIBRARY_VERSION=2.1.0
-LIBRARY_COMPOSE_VERSION=2.1.7
+LIBRARY_COMPOSE_VERSION=2.1.8
 MAPBOX_DOWNLOADS_TOKEN = "YOUR_MAPBOX_DOWNLOADS_TOKEN"

--- a/lib-compose/src/main/java/com/what3words/components/compose/maps/buttons/MapSwitchButton.kt
+++ b/lib-compose/src/main/java/com/what3words/components/compose/maps/buttons/MapSwitchButton.kt
@@ -66,8 +66,9 @@ internal fun MapSwitchButton(
             painter = painterResource(
                 id = when (mapType) {
                     W3WMapType.NORMAL -> R.drawable.ic_map_satellite
+                    W3WMapType.TERRAIN -> R.drawable.ic_map_satellite
                     W3WMapType.SATELLITE -> R.drawable.ic_map_normal
-                    else -> R.drawable.ic_map_satellite
+                    W3WMapType.HYBRID -> R.drawable.ic_map_normal
                 }
             ),
             contentDescription = contentDescription.mapSwitchButtonDescription,


### PR DESCRIPTION
Resolves a bug where the MapType icon fails to update its visual state when the user interacts with it.

<img width="1080" height="2400" alt="Android_WhatsApp_20260409_182744" src="https://github.com/user-attachments/assets/354a4aa0-21d3-4e25-8a67-dc9b953f863e" />