### PR TITLE
Add cleanup logic for mapbox

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -23,5 +23,5 @@ android.nonTransitiveRClass=true
 kotlin.code.style=official
 android.nonFinalResIds=false
 LIBRARY_VERSION=2.1.0
-LIBRARY_COMPOSE_VERSION=2.1.8
+LIBRARY_COMPOSE_VERSION=2.1.9
 MAPBOX_DOWNLOADS_TOKEN = "YOUR_MAPBOX_DOWNLOADS_TOKEN"

--- a/lib-compose/src/main/java/com/what3words/components/compose/maps/providers/mapbox/W3WMapBox.kt
+++ b/lib-compose/src/main/java/com/what3words/components/compose/maps/providers/mapbox/W3WMapBox.kt
@@ -18,7 +18,7 @@ import com.mapbox.maps.CameraOptions
 import com.mapbox.maps.EdgeInsets
 import com.mapbox.maps.MapView
 import com.mapbox.maps.MapboxMap
-import com.mapbox.maps.extension.compose.MapEffect
+import com.mapbox.maps.extension.compose.DisposableMapEffect
 import com.mapbox.maps.extension.compose.MapboxMap
 import com.mapbox.maps.extension.compose.rememberMapState
 import com.mapbox.maps.extension.compose.style.BooleanValue
@@ -250,7 +250,7 @@ fun W3WMapBox(
             )
         }
     ) {
-        MapEffect(Unit) {
+        DisposableMapEffect(Unit) {
             val cameraBounds = CameraBoundsOptions.Builder()
                 // Zoom out to continent level only, prevent zooming to the Earth. Zoom levels detail: https://docs.mapbox.com/help/glossary/zoom-level/
                 .minZoom(MAPBOX_MIN_ZOOM_LEVEL)
@@ -275,14 +275,14 @@ fun W3WMapBox(
                 true
             }
 
-            it.mapboxMap.subscribeMapIdle {
+            val mapIdleCancellable = it.mapboxMap.subscribeMapIdle {
                 if (state.cameraState.isCameraMoving) {
                     state.cameraState.isCameraMoving = false
                     onCameraUpdated(state.cameraState)
                 }
             }
 
-            it.mapboxMap.subscribeCameraChanged {
+            val cameraChangeCancellable = it.mapboxMap.subscribeCameraChanged {
                 if (!state.cameraState.isCameraMoving) {
                     state.cameraState.isCameraMoving = true
                     onCameraUpdated(state.cameraState)
@@ -296,6 +296,14 @@ fun W3WMapBox(
             }
 
             onMapLoaded?.invoke()
+
+            onDispose {
+                it.location.updateSettings {
+                    this.enabled = false
+                }
+                mapIdleCancellable.cancel()
+                cameraChangeCancellable.cancel()
+            }
         }
 
         W3WMapBoxDrawer(


### PR DESCRIPTION
This resolved the mapbox's warnings `Style object (accessing setStyleLayerProperty) should not be stored and used after MapView is destroyed or new style has been loaded` after switching to Google map

https://github.com/mapbox/mapbox-maps-android/issues/2017#issuecomment-2100636280