### PR TITLE
fix: blue dot not appearing on first-time location permission grant

### DIFF
--- a/lib-compose/src/main/java/com/what3words/components/compose/maps/providers/googlemap/W3WGoogleMap.kt
+++ b/lib-compose/src/main/java/com/what3words/components/compose/maps/providers/googlemap/W3WGoogleMap.kt
@@ -72,17 +72,21 @@ fun W3WGoogleMap(
     content: (@Composable () -> Unit)? = null
 ) {
     // Update the map properties based on map type, isMyLocationEnabled, and dark mode
-    val mapProperties = remember(state.mapType, state.isMyLocationEnabled, state.isDarkMode) {
-        MapProperties(
-            isBuildingEnabled = mapConfig.isBuildingEnable,
-            isIndoorEnabled = false,
-            mapType = state.mapType.toGoogleMapType(),
-            isMyLocationEnabled = state.isMyLocationEnabled,
-            mapStyleOptions = if (state.isDarkMode) mapConfig.darkModeCustomJsonStyle?.let {
-                MapStyleOptions(
-                    it
-                )
-            } else null
+    val mapProperties by remember(state.mapType, state.isMyLocationEnabled, state.isDarkMode) {
+        mutableStateOf(
+            MapProperties(
+                isBuildingEnabled = mapConfig.isBuildingEnable,
+                isIndoorEnabled = false,
+                mapType = state.mapType.toGoogleMapType(),
+                isMyLocationEnabled = state.isMyLocationEnabled,
+                mapStyleOptions = if (state.isDarkMode) mapConfig.darkModeCustomJsonStyle?.let {
+                    MapStyleOptions(
+                        it
+                    )
+                } else {
+                    null
+                }
+            )
         )
     }
 

--- a/lib-compose/src/main/java/com/what3words/components/compose/maps/providers/mapbox/W3WMapBox.kt
+++ b/lib-compose/src/main/java/com/what3words/components/compose/maps/providers/mapbox/W3WMapBox.kt
@@ -19,6 +19,7 @@ import com.mapbox.maps.EdgeInsets
 import com.mapbox.maps.MapView
 import com.mapbox.maps.MapboxMap
 import com.mapbox.maps.extension.compose.DisposableMapEffect
+import com.mapbox.maps.extension.compose.MapEffect
 import com.mapbox.maps.extension.compose.MapboxMap
 import com.mapbox.maps.extension.compose.rememberMapState
 import com.mapbox.maps.extension.compose.style.BooleanValue
@@ -126,16 +127,7 @@ fun W3WMapBox(
             }.launchIn(this)
     }
 
-
     val mapState = rememberMapState()
-
-    LaunchedEffect(state.isMyLocationEnabled) {
-        mapView?.let {
-            it.location.updateSettings {
-                enabled = state.isMyLocationEnabled
-            }
-        }
-    }
 
     LaunchedEffect(state.isMapGestureEnable) {
         state.isMapGestureEnable.let {
@@ -253,6 +245,12 @@ fun W3WMapBox(
             )
         }
     ) {
+        MapEffect(state.isMyLocationEnabled) { mapView ->
+            mapView.location.updateSettings {
+                enabled = state.isMyLocationEnabled
+            }
+        }
+
         DisposableMapEffect(Unit) {
             val cameraBounds = CameraBoundsOptions.Builder()
                 // Zoom out to continent level only, prevent zooming to the Earth. Zoom levels detail: https://docs.mapbox.com/help/glossary/zoom-level/


### PR DESCRIPTION
## Summary

- **Google Maps**: Wrap `MapProperties` in `mutableStateOf` (with `by` delegate) so Compose properly observes `isMyLocationEnabled` changes and triggers recomposition when location permission is first granted.
- **Mapbox**: Replace `LaunchedEffect(state.isMyLocationEnabled)` with `MapEffect(state.isMyLocationEnabled)` inside the `MapboxMap` block to eliminate the nullable `mapView` race condition — `MapEffect` always receives a valid, non-null `mapView` reference.

## Test plan

- [x] Grant location permission for the first time on a fresh install — verify the blue dot appears immediately on both Google Maps and Mapbox.
- [x] Revoke and re-grant location permission — verify the blue dot toggles correctly.
- [x] Verify no regression when `isMyLocationEnabled` is `false` (dot should not appear).

🤖 Generated with [Firebender](https://firebender.com)